### PR TITLE
Forward 'q' key to TC to allow closing the lister

### DIFF
--- a/EdgeViewer/EdgeLister.cpp
+++ b/EdgeViewer/EdgeLister.cpp
@@ -71,8 +71,8 @@ LRESULT EdgeLister::pluginWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM
 
 		case WM_WEBVIEW_JS_KEYDOWN:
 			{
-				// pass hotkeys 1-8
-				if (wParam >= '1' && wParam <= '8')
+				// pass hotkeys 1-8, and 'q'/'Q' to allow closing the lister
+				if ((wParam >= '1' && wParam <= '8') || wParam == 'Q')
 					PostMessage(GetParent(hWnd), WM_KEYDOWN, wParam, NULL);
 				break;
 			}

--- a/EdgeViewer/WebView2.cpp
+++ b/EdgeViewer/WebView2.cpp
@@ -237,7 +237,7 @@ HRESULT CreateWebView2Environment(HWND hWnd, const std::wstring& fileToLoad, con
 								}).Get(), &token);
 
 							webview->AddScriptToExecuteOnDocumentCreated(
-								L"window.addEventListener('keydown', event => { window.chrome.webview.postMessage('CMD_KEY|' + event.keyCode); });",
+								L"window.addEventListener('keydown', event => { if (event.code === 'KeyQ') window.chrome.webview.postMessage('CMD_KEY|81'); else if (event.code >= 'Digit1' && event.code <= 'Digit8') window.chrome.webview.postMessage('CMD_KEY|' + event.code.charCodeAt(5)); });",
 								nullptr);
 
 							AddApplyStyleScript(webview);


### PR DESCRIPTION
Total Commander's default lister closes on 'q', but JS keydown events were only forwarded to the parent window for hotkeys 1-8. Extending the filter to include 'Q' (JS keyCode 81, covers both cases regardless of Shift state) restores the expected close behaviour.